### PR TITLE
Change target width units to mm

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ class Config:
     DEFAULT_MAX_HEIGHT = 5.0  # mm
 
     # Configuración de imagen
-    DEFAULT_TARGET_WIDTH = 100  # píxeles
+    DEFAULT_TARGET_WIDTH_MM = 100  # ancho objetivo en milímetros
     DEFAULT_NUM_COLORS = 4  # número de colores a extraer
 
     # Configuración de escala

--- a/gui.py
+++ b/gui.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 from tkinter import colorchooser
+from config import Config
 import os
 from pathlib import Path
 
@@ -42,8 +43,8 @@ class HueForgeGUI:
         ttk.Entry(config_frame, textvariable=self.num_colors_var, width=10).grid(row=0, column=1, sticky=tk.W, padx=5)
 
         # Ancho objetivo
-        ttk.Label(config_frame, text="Ancho objetivo (px):").grid(row=1, column=0, sticky=tk.W)
-        self.width_var = tk.StringVar(value="100")
+        ttk.Label(config_frame, text="Ancho objetivo (mm):").grid(row=1, column=0, sticky=tk.W)
+        self.width_var = tk.StringVar(value=str(Config.DEFAULT_TARGET_WIDTH_MM))
         ttk.Entry(config_frame, textvariable=self.width_var, width=10).grid(row=1, column=1, sticky=tk.W, padx=5)
 
         # Grosor base
@@ -89,7 +90,7 @@ class HueForgeGUI:
         try:
             # Obtener parámetros
             num_colors = int(self.num_colors_var.get())
-            target_width = int(self.width_var.get())
+            target_width_mm = float(self.width_var.get())
             base_thickness = float(self.base_thickness_var.get())
             max_height = float(self.max_height_var.get())
 
@@ -112,7 +113,8 @@ class HueForgeGUI:
                 image_path=self.image_path,
                 output_dir=output_dir,
                 num_colors=num_colors,
-                target_width=target_width
+                target_width_mm=target_width_mm,
+                scale=Config.DEFAULT_SCALE
             )
 
             self.progress_bar.stop()


### PR DESCRIPTION
## Summary
- configure default target width in millimeters
- update GUI to accept width in mm
- convert width in process_image from mm to pixels
- pass scale through to STL builders

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `python hueforge_converter.py >/tmp/script.log && tail -n 20 /tmp/script.log`

------
https://chatgpt.com/codex/tasks/task_b_6878e89b38a0832788fb17a7e906cadb