### PR TITLE
Implement dated output directory

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,5 +17,5 @@ class Config:
     SUPPORTED_FORMATS = ['.jpg', '.jpeg', '.png', '.bmp', '.tiff', '.webp']
 
     # Configuración de salida
-    OUTPUT_DIR = "output_hueforge"
+    OUTPUT_DIR = "output"
     VISUALIZATION_DPI = 300

--- a/gui.py
+++ b/gui.py
@@ -116,7 +116,8 @@ class HueForgeGUI:
             self.root.update()
 
             # Procesar
-            output_dir = f"output_{Path(self.image_path).stem}"
+            from utils import create_output_directory
+            output_dir = create_output_directory(self.image_path, Config.OUTPUT_DIR)
             converter.process_image(
                 image_path=self.image_path,
                 output_dir=output_dir,

--- a/hueforge_converter.py
+++ b/hueforge_converter.py
@@ -342,7 +342,8 @@ def main():
 
     # Procesar imagen
     image_path = "input_image.jpg"  # Cambiar por tu imagen
-    output_dir = "output_hueforge"
+    from utils import create_output_directory
+    output_dir = create_output_directory(image_path, Config.OUTPUT_DIR)
 
     converter.process_image(
         image_path=image_path,

--- a/utils.py
+++ b/utils.py
@@ -67,3 +67,31 @@ G28 ; home all axes
 M190 S{bed_temp} ; set bed temperature
 M109 S{nozzle_temp} ; set nozzle temperature
 """
+
+
+def create_output_directory(image_path, root_dir):
+    """Crea la carpeta de salida siguiendo la estructura solicitada.
+
+    Args:
+        image_path (str): Ruta de la imagen original.
+        root_dir (str): Carpeta base de salida.
+
+    Returns:
+        str: Ruta completa de la carpeta de salida generada.
+    """
+    from datetime import datetime
+    from pathlib import Path
+
+    date_folder = datetime.now().strftime("%y%m%d")
+    base_dir = Path(root_dir) / date_folder
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    image_name = Path(image_path).stem
+    output_dir = base_dir / image_name
+    counter = 1
+    while output_dir.exists():
+        output_dir = base_dir / f"{image_name}({counter})"
+        counter += 1
+
+    output_dir.mkdir()
+    return str(output_dir)


### PR DESCRIPTION
## Summary
- store output under `output/<yymmdd>/<imagename>` so files are organized by date and image
- add helper `create_output_directory` in `utils.py`
- use new helper in GUI and CLI example
- update default `OUTPUT_DIR` config

## Testing
- `python -m py_compile config.py gui.py hueforge_converter.py utils.py`

------
https://chatgpt.com/codex/tasks/task_b_687a08aeed5c8327a15cd22cf30ba542